### PR TITLE
Don't process single click events that immediate follow a double click

### DIFF
--- a/NotifyIconWin32/NotificationAreaIcon.h
+++ b/NotifyIconWin32/NotificationAreaIcon.h
@@ -49,6 +49,9 @@ namespace NotifyIcon {
 
 			// Store the dispatcher for the UI thread to ensure events are raised on that thread
 			Dispatcher^ _ui_dispatcher = nullptr;
+
+			// Track when we are handling a double click
+			bool _handling_double_click = false;
 			
 			// Add the icon to the notification area
 			bool AddOrModify();


### PR DESCRIPTION
3 events are fired in the case of a double click. The order of events is:

Single click (canceled) -> double click (executed) -> single click (executed)

The first single click event's timer is canceled as expected. The double click event immediately fires. The second single click event then fires and displays the menu since there is nothing cancelling its timer.

We now flag when we are handling a double click. When a double click event is being handled, it is assigned a timer that cannot be deleted by immediate single click events. Single click events are ignored until the double click event is handled.

The new order of events is:

Single click (canceled) -> double click (executed) -> single click (ignored)

