### PR TITLE
Periodically refresh the icon to recover from potential Explorer crash

### DIFF
--- a/NotifyIconWin32/NotificationAreaIcon.cpp
+++ b/NotifyIconWin32/NotificationAreaIcon.cpp
@@ -57,7 +57,8 @@ bool NotificationAreaIcon::AddOrModify()
 		// Delete the icon, in case a previous version exists
 		Delete();
 		// Now try to add the new icon
-		_is_added = Shell_NotifyIcon(NIM_ADD, _icon_data);
+		// Using just NIM_ADD can lead to issues if Explorer crashes, mitigated by also calling NIM_MODIFY
+		_is_added = Shell_NotifyIcon(NIM_ADD, _icon_data) && Shell_NotifyIcon(NIM_MODIFY, _icon_data);
 		if (!_is_added) {
 			Error^ error = gcnew Error();
 			error->ThrowAsException();

--- a/NotifyIconWin32/NotificationAreaIcon.cpp
+++ b/NotifyIconWin32/NotificationAreaIcon.cpp
@@ -42,6 +42,14 @@ void NotificationAreaIcon::HideIcon()
 	SetVersion();
 }
 
+void NotificationAreaIcon::RefreshIcon() {
+	try {
+		Shell_NotifyIcon(NIM_ADD, _icon_data);
+		Shell_NotifyIcon(NIM_MODIFY, _icon_data);
+	}
+	catch (...) { }
+}
+
 // Set the foreground window to the given window
 // Used to show the context menu
 bool NotificationAreaIcon::SetForegroundWindow(IntPtr hwndWindow)
@@ -57,8 +65,7 @@ bool NotificationAreaIcon::AddOrModify()
 		// Delete the icon, in case a previous version exists
 		Delete();
 		// Now try to add the new icon
-		// Using just NIM_ADD can lead to issues if Explorer crashes, mitigated by also calling NIM_MODIFY
-		_is_added = Shell_NotifyIcon(NIM_ADD, _icon_data) && Shell_NotifyIcon(NIM_MODIFY, _icon_data);
+		_is_added = Shell_NotifyIcon(NIM_ADD, _icon_data);
 		if (!_is_added) {
 			Error^ error = gcnew Error();
 			error->ThrowAsException();

--- a/NotifyIconWin32/NotificationAreaIcon.h
+++ b/NotifyIconWin32/NotificationAreaIcon.h
@@ -109,6 +109,9 @@ namespace NotifyIcon {
 			// Hide the notification area icon
 			void HideIcon();
 
+			// Used to periodically add/modify icon, used mitigate issues with Explorer crashing
+			void RefreshIcon();
+
 			// Set the foreground window to the given window
 			// Used to show the context menu
 			static bool SetForegroundWindow(IntPtr hwndWindow);

--- a/NotifyIconWpf/NotifyIconComponent.cs
+++ b/NotifyIconWpf/NotifyIconComponent.cs
@@ -6,6 +6,7 @@ using NotifyIcon.Win32;
 using System.Windows.Controls.Primitives;
 using System.Windows.Interop;
 using System.Windows.Threading;
+using System.Threading.Tasks;
 
 namespace NotifyIcon.Wpf
 {
@@ -21,6 +22,9 @@ namespace NotifyIcon.Wpf
 
         // The icon to display
         private Icon _icon;
+
+        // Icon refresh interval
+        private const int _refreshInterval = 300000;
 
         #endregion Members
 
@@ -86,6 +90,12 @@ namespace NotifyIcon.Wpf
 
             // Show the icon
             _notifyIcon.ShowIcon();
+
+            // Periodically check the icon (every 5 min)
+            Task.Run(async () => {
+                await Task.Delay(_refreshInterval);
+                RefreshIcon();
+            });
         }
 
         // Hide the notification icon
@@ -102,6 +112,16 @@ namespace NotifyIcon.Wpf
         {
             NotifyIconComponent source = d as NotifyIconComponent;
             source?.OnIconChanged(e);
+        }
+
+        private void RefreshIcon() {
+            _notifyIcon?.RefreshIcon();
+
+            // Periodically check the icon (every 5 min)
+            Task.Run(async () => {
+                await Task.Delay(_refreshInterval);
+                RefreshIcon();
+            });
         }
 
         private void OnIconChanged(DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
Cited issue: "Issue: If Explorer crashes, tray icons added this way will not reappear until the user manually restarts the program so that it uses the NIM_ADD flag.  Usually this means that the tray icons and any notifications from the affected programs will not show until the user signs out or reboots."

Common fix: "Periodically call Shell_NotifyIcon with the NIM_ADD flag and immediately call it again with the NIM_MODIFY flag"