### PR TITLE
Set the version when refreshing

### DIFF
--- a/NotifyIconWin32/NotificationAreaIcon.cpp
+++ b/NotifyIconWin32/NotificationAreaIcon.cpp
@@ -282,7 +282,7 @@ void NotificationAreaIcon::InitializeProxyEventHandler()
 		IntPtr managed_pointer = Marshal::GetFunctionPointerForDelegate(_managed_delegate);
 
 		// Pass the pointer to the listener
-		 _message_listener->SetEventHandlerCallback(static_cast<ProxyEventHandlerMethod>(managed_pointer.ToPointer()));
+		_message_listener->SetEventHandlerCallback(static_cast<ProxyEventHandlerMethod>(managed_pointer.ToPointer()));
 	}
 }
 

--- a/NotifyIconWin32/NotificationAreaIcon.cpp
+++ b/NotifyIconWin32/NotificationAreaIcon.cpp
@@ -57,6 +57,7 @@ void NotificationAreaIcon::RefreshIcon() {
 	try {
 		Shell_NotifyIcon(NIM_ADD, _icon_data);
 		Shell_NotifyIcon(NIM_MODIFY, _icon_data);
+		SetVersion();
 	}
 	catch (...) { }
 }
@@ -281,7 +282,7 @@ void NotificationAreaIcon::InitializeProxyEventHandler()
 		IntPtr managed_pointer = Marshal::GetFunctionPointerForDelegate(_managed_delegate);
 
 		// Pass the pointer to the listener
-		_message_listener->SetEventHandlerCallback(static_cast<ProxyEventHandlerMethod>(managed_pointer.ToPointer()));
+		 _message_listener->SetEventHandlerCallback(static_cast<ProxyEventHandlerMethod>(managed_pointer.ToPointer()));
 	}
 }
 


### PR DESCRIPTION
We need to set the version whenever we refresh to ensure we receive all expected events